### PR TITLE
Fixes a deprecation introduced in Rails 3.1's ActionView template handler

### DIFF
--- a/lib/iq_rdf/rails/iq_rdf.rb
+++ b/lib/iq_rdf/rails/iq_rdf.rb
@@ -12,31 +12,32 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-module ActionView::TemplateHandlers
+module ActionView
+  module Template::Handlers
 
-  class IqRdf < ActionView::TemplateHandler
-    include ActionView::TemplateHandlers::Compilable
+    class IqRdf
 
-    def compile(template)
-      <<-EOV
+      def self.call(template)
+        <<-EOV
 
-      document = IqRdf::Document.new()
-      #{template.source}
-      if params[:format].to_s == "ttl"
-        controller.response.headers["Content-Type"] ||= 'text/turtle'
-        document.to_turtle
-      elsif  params[:format].to_s == "nt"
-        controller.response.headers["Content-Type"] ||= 'text/plain'
-        document.to_ntriples
-      elsif params[:format].to_s == "rdf"
-        controller.response.headers["Content-Type"] ||= 'application/xml+rdf'
-        document.to_xml
-      else # Default => turtle
-        controller.response.headers["Content-Type"] ||= 'text/turtle'
-        document.to_turtle
+        document = IqRdf::Document.new()
+        #{template.source}
+        if params[:format].to_s == "ttl"
+          controller.response.headers["Content-Type"] ||= 'text/turtle'
+          document.to_turtle
+        elsif  params[:format].to_s == "nt"
+          controller.response.headers["Content-Type"] ||= 'text/plain'
+          document.to_ntriples
+        elsif params[:format].to_s == "rdf"
+          controller.response.headers["Content-Type"] ||= 'application/xml+rdf'
+          document.to_xml
+        else # Default => turtle
+          controller.response.headers["Content-Type"] ||= 'text/turtle'
+          document.to_turtle
+        end
+        EOV
       end
-      EOV
     end
+    
   end
-  
 end


### PR DESCRIPTION
Rails wants template handlers to just implement a "call" class method from now on. Inheriting and including is deprecated.

Fix has been tested against Rails 3.1 and Rails 3.0.10.
